### PR TITLE
DtriosParallel support for new Dtrios options and multiple VCF files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,36 +128,41 @@ The output files with suffixes  `BBAA.txt`, `Dmin.txt`, and optionally `tree.txt
 
 The output files with suffixes  `combine.txt` and  `combine_stderr.txt` are used as input to DtriosCombine. If you don't need to use DtriosCombine, you can safely delete these files.
 
-### Wrapper for parallel execution of Dsuite Dtrios
+### DtriosParallel
 
-We provide a python script for parallel execution at `<Dsuite_path>/utils/DtriosParallel`. The usage is analogous to Dsuite Dtrios.
+We provide a python script for parallel execution at `<Dsuite_path>/utils/DtriosParallel`. The usage is analogous to Dsuite Dtrios, except that the order of `SETS.txt` and `INPUT_FILE.vcf` is swapped in the command line so that the user can optionally provide multiple VCF files (whitespace separated). The script will autmatically call `DtriosCombine` to combine results of all VCF files into a single set of results files.
 
 ```
 $ ./utils/DtriosParallel --help
-usage: DtriosParallel [-h] [--cores CORES] [-k JKNUM] [-j JKWINDOW] [-t TREE]
-                      [-n RUN_NAME] [--keep-intermediate]
+usage: DtriosParallel [-h] [-k JKNUM] [-j JKWINDOW] [-t TREE] [-n RUN_NAME]
+                      [-l NUMLINES] [-g] [-p --pool-seq=MIN_DEPTH] [-c]
+                      [--cores CORES] [--keep-intermediate]
                       [--logging_level {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
                       [--dsuite-path DSUITE_PATH]
                       [--environment-setup ENVIRONMENT_SETUP]
-                      INPUT_FILE.vcf SETS.txt
+                      SETS.txt INPUT_FILE.vcf [INPUT_FILE.vcf ...]
 
 This python script automates parallelisation of Dsuite Dtrios/ Dsuite
 DtriosCombine. The usage is analogous to Dsuite Dtrios but computation is
-performed on multiple cores (default: number of available CPUs). It should run
-on most systems with a standard python installation (tested with python 2.7
-and 3.6).
+performed on multiple cores (default: number of available CPUs). ATTENTION:
+The order of SETS.txt and INPUT_FILE.vcf is swapped compared to Dsuite Dtrios.
+This is so that multiple VCF input files can be provided. All vcf files should
+have the same samples, (e.g., different chromosomes of the same callset).
+Output_files are placed in the same folder as as the the SETS.txt file and
+named DTParallel_<SETS_basename>_<run_name>_combined_BBAA.txt etc. This script
+should run on most systems with a standard python installation (tested with
+python 2.7 and 3.6).
+
 
 positional arguments:
-  INPUT_FILE.vcf
   SETS.txt              The SETS.txt should have two columns: SAMPLE_ID
                         SPECIES_ID The outgroup (can be multiple samples)
                         should be specified by using the keyword Outgroup in
                         place of the SPECIES_ID
+  INPUT_FILE.vcf        One or more whitespace separated SNP vcf files.
 
 optional arguments:
   -h, --help            show this help message and exit
-  --cores CORES         (default=CPU count) Number of Dsuite Dtrios processes
-                        run in parallel.
   -k JKNUM, --JKnum JKNUM
                         (default=20) the number of Jackknife blocks to divide
                         the dataset into; should be at least 20 for the whole
@@ -172,8 +177,25 @@ optional arguments:
                         tree will be output in a file with _tree.txt suffix
   -n RUN_NAME, --run-name RUN_NAME
                         run-name will be included in the output file name
+  -l NUMLINES           (optional) the number of lines (SNPs) in the VCF
+                        input(s) - speeds up operation if known. If N
+                        INPUT_FILE.vcf files are provided, there must be N
+                        comma-separated integers provided without whitespace
+                        between them.
+  -g, --use-genotype-probabilities
+                        (optional) use probabilities (GP tag) or calculate
+                        them from likelihoods (GL or PL tags) using a Hardy-
+                        Weinberg prior
+  -p --pool-seq=MIN_DEPTH, --pool-seq --pool-seq=MIN_DEPTH
+                        (default=20) the number of Jackknife blocks to divide
+                        the dataset into; should be at least 20 for the whole
+                        dataset
+  -c, --no-combine      (optional) do not run DtriosCombine to obtain a single
+                        combined results file
+  --cores CORES         (default=CPU count) Number of Dsuite Dtrios processes
+                        run in parallel.
   --keep-intermediate   Keep region-wise Dsuite Dtrios results.
-  --logging_level {DEBUG,INFO,WARNING,ERROR,CRITICAL}, -l {DEBUG,INFO,WARNING,ERROR,CRITICAL}
+  --logging_level {DEBUG,INFO,WARNING,ERROR,CRITICAL}, -v {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                         Minimun level of logging.
   --dsuite-path DSUITE_PATH
                         Explicitly set the path to the directory in which
@@ -183,9 +205,14 @@ optional arguments:
   --environment-setup ENVIRONMENT_SETUP
                         Command that should be run to setup the environment
                         for Dsuite. E.g., 'module load GCC' or 'conda
-                        activate'
+
 
 ```
+
+#### Output:
+
+Output are \_BBAA, \_Dmin files analogus to Dtrios/DtriosCombine and are placed in the same folder as as the the `SETS.txt` file and
+named `DTParallel_<SETS_basename>_<run_name>_combined_BBAA.txt` etc.
 
 ### DtriosCombine - Combine results from Dtrios runs across genomic regions (e.g. per chromosome)
 ```

--- a/README.md
+++ b/README.md
@@ -121,6 +121,65 @@ The output files with suffixes  `BBAA.txt`, `Dmin.txt`, and optionally `tree.txt
 
 The output files with suffixes  `combine.txt` and  `combine_stderr.txt` are used as input to DtriosCombine. If you don't need to use DtriosCombine, you can safely delete these files.
 
+### Wrapper for parallel execution of Dsuite Dtrios
+
+We provide a python script for parallel execution at `<Dsuite_path>/utils/DtriosParallel`. The usage is analogous to Dsuite Dtrios.
+
+```
+$ ./utils/DtriosParallel --help
+usage: DtriosParallel [-h] [--cores CORES] [-k JKNUM] [-j JKWINDOW] [-t TREE]
+                      [-n RUN_NAME] [--keep-intermediate]
+                      [--logging_level {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
+                      [--dsuite-path DSUITE_PATH]
+                      [--environment-setup ENVIRONMENT_SETUP]
+                      INPUT_FILE.vcf SETS.txt
+
+This python script automates parallelisation of Dsuite Dtrios/ Dsuite
+DtriosCombine. The usage is analogous to Dsuite Dtrios but computation is
+performed on multiple cores (default: number of available CPUs). It should run
+on most systems with a standard python installation (tested with python 2.7
+and 3.6).
+
+positional arguments:
+  INPUT_FILE.vcf
+  SETS.txt              The SETS.txt should have two columns: SAMPLE_ID
+                        SPECIES_ID The outgroup (can be multiple samples)
+                        should be specified by using the keyword Outgroup in
+                        place of the SPECIES_ID
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --cores CORES         (default=CPU count) Number of Dsuite Dtrios processes
+                        run in parallel.
+  -k JKNUM, --JKnum JKNUM
+                        (default=20) the number of Jackknife blocks to divide
+                        the dataset into; should be at least 20 for the whole
+                        dataset
+  -j JKWINDOW, --JKwindow JKWINDOW
+                        Jackknife block size in number of informative SNPs (as
+                        used in v0.2) when specified, this is used in place of
+                        the --JKnum option
+  -t TREE, --tree TREE  a file with a tree in the newick format specifying the
+                        relationships between populations/species D and
+                        f4-ratio values for trios arranged according to the
+                        tree will be output in a file with _tree.txt suffix
+  -n RUN_NAME, --run-name RUN_NAME
+                        run-name will be included in the output file name
+  --keep-intermediate   Keep region-wise Dsuite Dtrios results.
+  --logging_level {DEBUG,INFO,WARNING,ERROR,CRITICAL}, -l {DEBUG,INFO,WARNING,ERROR,CRITICAL}
+                        Minimun level of logging.
+  --dsuite-path DSUITE_PATH
+                        Explicitly set the path to the directory in which
+                        Dsuite is located. By default the script will first
+                        check whether Dsuite is accessible from $PATH. If not
+                        it will try to locate Dsuite at ../Build/Dsuite.
+  --environment-setup ENVIRONMENT_SETUP
+                        Command that should be run to setup the environment
+                        for Dsuite. E.g., 'module load GCC' or 'conda
+                        activate'
+
+```
+
 ### DtriosCombine - Combine results from Dtrios runs across genomic regions (e.g. per chromosome)
 ```
 Usage: Dsuite DtriosCombine [OPTIONS] DminFile1 DminFile2 DminFile3 ....

--- a/utils/DtriosParallel
+++ b/utils/DtriosParallel
@@ -46,9 +46,12 @@ def get_n_snps(vcf_fn):
     return n_snps
         
     
-def dsuite_dtrios(vcf_fn, sets_fn, run_name, n_cores, tree_fn=None,JKnum=None,
+def dsuite_dtrios(vcf_fn, sets_fn, run_name, n_cores, tree_fn=None, JKnum=None,
                   JKwindow=None,
-                  n_snps=None, dsuite_path='', environment_setup=''):
+                  n_snps=None, dsuite_path='', environment_setup='',
+                  use_genotype_probabilities=False,
+                  pool_seq=None
+                  ):
     
     if n_snps is None:
         n_snps = get_n_snps(vcf_fn)
@@ -84,15 +87,26 @@ def dsuite_dtrios(vcf_fn, sets_fn, run_name, n_cores, tree_fn=None,JKnum=None,
     else:
         jkwindow_str = "--JKwindow {}".format(JKwindow)
 
+    if use_genotype_probabilities:
+        gt_prob_str = "--use-genotype-probabilities"
+    else:
+        gt_prob_str = ""
+
+    if pool_seq is not None:
+        pool_seq_str = "--pool-seq {}".format(pool_seq)
+    else:
+        pool_seq_str = ""
+
     processes = []
     commands = []
     for start in starts:
         command_str = ('{environment_setup} {dsuite_path}Dsuite Dtrios {run_str} {tree_str} {jknum_str}'
-                       '{jkwindow_str}  --region={start},{lines_per_core} {vcf_fn} {sets_fn}'.format(
+                       '{jkwindow_str} {gt_prob_str} {pool_seq_str} --region={start},{lines_per_core} {vcf_fn} {sets_fn}'.format(
                            environment_setup=environment_setup, dsuite_path=dsuite_path,
                            run_str=run_str, tree_str=tree_str, 
                            jknum_str=jknum_str, jkwindow_str=jkwindow_str, start=start, 
-                           lines_per_core=lines_per_core, vcf_fn=vcf_fn, sets_fn=sets_fn))
+                           lines_per_core=lines_per_core, vcf_fn=vcf_fn, sets_fn=sets_fn,
+                            gt_prob_str=gt_prob_str, pool_seq_str=pool_seq_str))
         logging.info('Starting process: {command_str}'.format(command_str=command_str))
         p = subprocess.Popen(command_str,
                          shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -152,7 +166,7 @@ def dsuite_combine(sets_fn, run_name, starts, lines_per_core, tree_fn=None,
     #print('------------------------------------------------------', file=sys.stderr)
     logging.info('Combining output from {} runs with: '.format(len(starts)) + combine_command)
 
-    p = subprocess.Popen( combine_command,
+    p = subprocess.Popen(combine_command,
                          shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     o, e = p.communicate()
@@ -167,7 +181,7 @@ def dsuite_combine(sets_fn, run_name, starts, lines_per_core, tree_fn=None,
     else:
         if e:
             logging.debug(e)
-            logging.info('Successfully combined {} runs into outoput files'
+            logging.info('Successfully combined {} runs into output files'
               ' with base {}.'.format(len(starts),
                                                 os.path.join(sets_dir,"out_" +
                                                             run_name+'_combined')))
@@ -209,9 +223,9 @@ def main():
                         help=("The SETS.txt should have two columns: SAMPLE_ID    SPECIES_ID\n"
                         "The outgroup (can be multiple samples) should be specified by using the "
                         "keyword Outgroup in place of the SPECIES_ID"))
-    parser.add_argument("--cores", type=int,
-                                help=("(default=CPU count) Number of Dsuite Dtrios processes run in parallel."),
-                                                        default=None)     
+
+
+    #DSUITE options
     parser.add_argument("-k", "--JKnum", type=int,
                                 help=("(default=20) the number of Jackknife blocks to divide the dataset into;"
                                       " should be at least 20 for the whole dataset"),
@@ -229,9 +243,30 @@ def main():
     parser.add_argument("-n", "--run-name", type=str,
                         help="run-name will be included in the output file name",
                         required=False)
+
+    parser.add_argument("-l",metavar='NUMLINES', type=int,
+                                help=("(optional) the number of lines (SNPs) in the VCF input - speeds up operation if known"),
+                                                        default=None)
+
+    parser.add_argument("-g", "--use-genotype-probabilities", action='store_true',
+                        help=("(optional) use probabilities (GP tag) or calculate them from "
+                              "likelihoods (GL or PL tags) using a Hardy-Weinberg prior"))
+
+    parser.add_argument("-p", "--pool-seq", metavar="--pool-seq=MIN_DEPTH", type=int,
+                                help=("(default=20) the number of Jackknife blocks to divide the dataset into;"
+                                      " should be at least 20 for the whole dataset"),
+                                                        default=None)
+    parser.add_argument("-c", "--no-combine", action='store_true',
+                        help=("(optional) do not run DtriosCombine to obtain a single combined results file"))
+
+
+    # DtriosParallel specific options
+    parser.add_argument("--cores", type=int,
+                                help=("(default=CPU count) Number of Dsuite Dtrios processes run in parallel."),
+                                                        default=None)
     parser.add_argument( "--keep-intermediate", action='store_true',
                         help="Keep region-wise Dsuite Dtrios results.")
-    parser.add_argument('--logging_level','-l',
+    parser.add_argument('--logging_level','-v',
                                     choices=['DEBUG','INFO','WARNING','ERROR','CRITICAL'],
                                                             default='INFO',
                                                             help='Minimun level of logging.')
@@ -298,16 +333,28 @@ def main():
     vcf_fn = os.path.abspath(args.vcf_fn)
     sets_fn = os.path.abspath(args.sets_fn)
 
-    n_snps = get_n_snps(args.vcf_fn)
-    
+    if args.l is None:
+        n_snps = get_n_snps(args.vcf_fn)
+    else:
+        n_snps = args.l
+
+
     lines_per_core, starts = dsuite_dtrios(vcf_fn, sets_fn, args.run_name, args.cores, tree_fn=args.tree,
                                             n_snps=n_snps, JKnum=args.JKnum, JKwindow=args.JKwindow,dsuite_path=args.dsuite_path,
-                                            environment_setup=args.environment_setup)
-    
-    rc = dsuite_combine(sets_fn, args.run_name, starts, lines_per_core, tree_fn=args.tree,
-                        remove_intermediate_files=not args.keep_intermediate, dsuite_path=args.dsuite_path, 
-                                                                    environment_setup=args.environment_setup)
+                                            environment_setup=args.environment_setup,
+                                           use_genotype_probabilities=args.use_genotype_probabilities,
+                                            pool_seq=args.pool_seq)
 
+    #lines_per_core = int(n_snps * 1. / args.cores) + 1
+    #starts = range(1, n_snps, lines_per_core)
+
+    if not args.no_combine:
+        rc = dsuite_combine(sets_fn, args.run_name, starts, lines_per_core, tree_fn=args.tree,
+                            remove_intermediate_files=not args.keep_intermediate, dsuite_path=args.dsuite_path,
+                                                                        environment_setup=args.environment_setup)
+
+    else:
+        rc = 0
 
     return rc
 

--- a/utils/DtriosParallel
+++ b/utils/DtriosParallel
@@ -11,6 +11,7 @@ from __future__ import (print_function, unicode_literals, division)
 
 import os, sys
 import subprocess
+from multiprocessing import Pool
 import argparse
 import logging
 
@@ -22,6 +23,8 @@ logging.basicConfig(format='%(levelname)-8s %(asctime)s  %(message)s')
 logger.setLevel(logging.DEBUG)
 
 
+out_prefix = 'DTparallel'
+
 
 def get_n_snps(vcf_fn):
     """
@@ -30,41 +33,37 @@ def get_n_snps(vcf_fn):
     vcf_ext = os.path.splitext(vcf_fn)[-1]
     catfun = 'gzip -dc' if vcf_ext in ['.gz','.bz'] else 'cat'
     
-    logging.info("Checking number of variants in {vcf_fn}".format(vcf_fn=vcf_fn))
+
 
     command = '{catfun} {vcf_fn} | grep -v "^#" | wc -l'.format(catfun=catfun, vcf_fn=vcf_fn)
     p = subprocess.Popen(command,
                      shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     n_snps, err = p.communicate(b"input data that is passed to subprocess' stdin")
     if p.returncode:
-        logging.error('{e}'.format(e=e))
+        #logging.error('{e}'.format(e=e))
         raise subprocess.CalledProcessError(p.returncode, command)
 
     n_snps = int(n_snps)
-    logging.info("{n_snps} variants in vcf.".format(n_snps=n_snps))
+
 
     return n_snps
         
-    
-def dsuite_dtrios(vcf_fn, sets_fn, run_name, n_cores, tree_fn=None, JKnum=None,
+
+
+def run_command(command_str):
+    p = subprocess.Popen(command_str,
+                         shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    o, e = p.communicate()
+    rc = p.returncode
+    return rc, o, e
+
+
+def dsuite_dtrios(vcf_fns, sets_fn, run_name, n_cores, tree_fn=None, JKnum=None,
                   JKwindow=None,
                   n_snps=None, dsuite_path='', environment_setup='',
                   use_genotype_probabilities=False,
                   pool_seq=None
                   ):
-    
-    if n_snps is None:
-        n_snps = get_n_snps(vcf_fn)
-    
-    if dsuite_path and dsuite_path[-1] != '/':
-        dsuite_path += '/'
-    
-    lines_per_core = int(n_snps*1./ n_cores) + 1
-    
-    logging.info("Parallelizing across {n_cores} cores. Regions of {lines_per_core} variants per core.".format(n_cores=n_cores, lines_per_core=lines_per_core))
-    
-    starts = range(1, n_snps, lines_per_core)
-
 
     if run_name is None:
         run_str = ''
@@ -75,7 +74,7 @@ def dsuite_dtrios(vcf_fn, sets_fn, run_name, n_cores, tree_fn=None, JKnum=None,
     if tree_fn is None:
         tree_str = ''
     else:
-        tree_str = "--tree {}".format(os.path.abspath(tree_fn))
+        tree_str = "--tree {}".format(tree_fn)
 
     if JKnum is None:
         jknum_str = ""
@@ -97,48 +96,114 @@ def dsuite_dtrios(vcf_fn, sets_fn, run_name, n_cores, tree_fn=None, JKnum=None,
     else:
         pool_seq_str = ""
 
-    processes = []
-    commands = []
-    for start in starts:
-        command_str = ('{environment_setup} {dsuite_path}Dsuite Dtrios {run_str} {tree_str} {jknum_str}'
-                       '{jkwindow_str} {gt_prob_str} {pool_seq_str} --region={start},{lines_per_core} {vcf_fn} {sets_fn}'.format(
-                           environment_setup=environment_setup, dsuite_path=dsuite_path,
-                           run_str=run_str, tree_str=tree_str, 
-                           jknum_str=jknum_str, jkwindow_str=jkwindow_str, start=start, 
-                           lines_per_core=lines_per_core, vcf_fn=vcf_fn, sets_fn=sets_fn,
-                            gt_prob_str=gt_prob_str, pool_seq_str=pool_seq_str))
-        logging.info('Starting process: {command_str}'.format(command_str=command_str))
-        p = subprocess.Popen(command_str,
-                         shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        commands.append(command_str)
-        processes.append(p)
+    sets_base = os.path.splitext(sets_fn)[0]
+
+    pool = Pool(n_cores)
 
 
-    for s, c, p in zip(starts, commands, processes):
-        o, e = p.communicate()
+    if n_snps is None:
+        logging.info("Checking number of variants in vcf file(s)")
+        snp_map = pool.map_async(get_n_snps, vcf_fns)
+        n_snps = snp_map.get()
+        logging.info("Lines in in vcf file(s): {n_snps}".format(n_snps=n_snps))
+
+    assert len(n_snps) == len(vcf_fns)
+
+    if dsuite_path and dsuite_path[-1] != '/':
+        dsuite_path += '/'
+
+    #determine number of chunks per vcf file based on cpus per file and line numbers
+    chunks_per_file = [1] * len(vcf_fns)
+    for i in range(len(vcf_fns), n_cores):
+        lines_per_chunk = [1. * a / b for a, b in zip(n_snps, chunks_per_file)]
+        most_lines_per_core = lines_per_chunk.index(max(lines_per_chunk))
+        chunks_per_file[most_lines_per_core] += 1
+
+    lines_per_chunk = [int(1. * a / b) + 1 for a, b in zip(n_snps, chunks_per_file)]
+
+    params = []
+    i = 0
+    for fn, n_snp, n_lines, n_chunks in zip(vcf_fns, n_snps, lines_per_chunk, chunks_per_file):
+        if n_chunks == 1:
+            params.append((i, fn, 0, 'all'))
+            i += 1
+        else:
+            for start in range(1, n_snp, n_lines):
+                params.append( (i, fn, start, n_lines))
+                i += 1
+
+    def get_command_str(i, vcf_fn, start, n_lines):
+
+        out_base = sets_base + '_' + str(i)
+
+        if n_lines == 'all':
+            region_str = ""
+        else:
+            region_str = "--region={start},{n_lines}".format(start=start, n_lines=n_lines)
+
+        command_str = (
+        '{environment_setup} {dsuite_path}Dsuite Dtrios --out-prefix {out_base} {run_str} {tree_str} {jknum_str}'
+        '{jkwindow_str} {gt_prob_str} {pool_seq_str} {region_str} {vcf_fn} {sets_fn}'.format(
+            environment_setup=environment_setup, dsuite_path=dsuite_path,
+            run_str=run_str, tree_str=tree_str,
+            jknum_str=jknum_str, jkwindow_str=jkwindow_str, region_str=region_str,
+            vcf_fn=vcf_fn, sets_fn=sets_fn,
+            gt_prob_str=gt_prob_str, pool_seq_str=pool_seq_str, out_base=out_base))
+        return command_str
+
+
+    logging.info("Parallelizing {n_vcfs} vcf files across {n_cores} cores. "
+                 "Using the following numbers of chunks per file based on line-numbers: {chunks_per_file}.".format(n_vcfs=len(vcf_fns),
+                                                                                                    n_cores=n_cores,
+                                                                                                    chunks_per_file=chunks_per_file))
+
+    dtrios_commnands = [get_command_str(*p) for p in params]
+
+    for c in dtrios_commnands:
+        logging.info('Starting process: {command_str}'.format(command_str=c))
+
+    
+    map_dsuite = pool.map_async(run_command, dtrios_commnands)
+
+    results = map_dsuite.get()
+
+    for (rc, o, e), c, (run_id, fn, start, n_lines) in zip(results, dtrios_commnands, params):
         o = o.decode('utf-8')
         e = e.decode('utf-8')
         if o:
-            print(o, file=sys.stdout)
-        if p.returncode:
+            logging.debug(o)
+        if rc:
             logging.error(e)
-            raise subprocess.CalledProcessError(p.returncode, c)
+            raise subprocess.CalledProcessError(rc, c)
         else:
             if e:
                 logging.debug('{e}'.format(e=e))
-            logging.info('Successfully finished process for interval starting at {s}'.format(s=s))
+            logging.info('Successfully finished process for parameters: fn={fn},'
+                         ' start={start}, n_lines={n_lines}'.format(fn=fn, start=start, n_lines=n_lines))
             #print('------------------------------------------------------', file=sys.stderr)
     
-    return lines_per_core, starts 
+    return params
     
-def dsuite_combine(sets_fn, run_name, starts, lines_per_core, tree_fn=None,
+def dsuite_combine(params, run_name, sets_fn,  tree_fn=None,
                    remove_intermediate_files=True, dsuite_path='',  environment_setup=''):
-    
+    """
+    Combine Dsuite Dtrios runs run with dsuite_dtrios()
+    :param params: This should be a list of tuples of length three,
+                    each containing combinations of (n_run, vcf_fn, start, n_lines)
+    :param run_name:
+    :param sets_fn:
+    :param tree_fn:
+    :param remove_intermediate_files:
+    :param dsuite_path:
+    :param environment_setup:
+    :return: Returncode of the Dsuite DtriosCombine command. (0 if no error)
+    """
     
     extensions = ['_combine.txt', '_combine_stderr.txt', '_BBAA.txt', '_Dmin.txt']
     
     sets_dir = os.path.dirname(os.path.abspath(sets_fn))
-    sets_base = os.path.splitext(os.path.abspath(sets_fn))[0]
+    sets_fn1 = os.path.basename(sets_fn)
+    sets_base = os.path.splitext(sets_fn1)[0]
 
     if dsuite_path and dsuite_path[-1] != '/':
         dsuite_path += '/'
@@ -152,19 +217,33 @@ def dsuite_combine(sets_fn, run_name, starts, lines_per_core, tree_fn=None,
     if tree_fn is None:
         tree_str = ''
     else:
-        tree_str = "--tree {}".format(os.path.abspath(tree_fn))
+        tree_str = "--tree {}".format(tree_fn)
 
-    outbases = ['{sets_base}_{run_name}_{s}_{e}'.format(sets_base=sets_base, run_name=run_name,s=s,
-                                                        e=s + lines_per_core) for s in starts]
+    outbases = []
 
-    combine_command = 'cd {sets_dir}; {environment_setup} {dsuite_path}Dsuite DtriosCombine --out-prefix out {run_str} {tree_str} '.format(
+
+    for (n_run, vcf_fn, start, n_lines) in params:
+        if n_lines == 'all':
+            region_str = ''
+        else:
+            region_str = "_{s}_{e}".format(s=start,e=start + n_lines)
+
+        outbase =  '{sets_base}_{n_run}_{run_name}{region_str}'.format(sets_base=sets_base,
+                                                                   n_run=n_run,run_name=run_name,
+                                                                       region_str=region_str)
+        outbases.append(outbase)
+
+
+    combine_command = 'cd {sets_dir}; {environment_setup} {dsuite_path}Dsuite DtriosCombine --out-prefix {out_prefix}_{sets_base} {run_str} {tree_str} '.format(
+                        out_prefix = out_prefix,
+                        sets_base=sets_base,
                         sets_dir=sets_dir,
                         environment_setup=environment_setup, dsuite_path=dsuite_path, run_str=run_str, tree_str=tree_str) \
                         + ' '.join(outbases)
 
 
     #print('------------------------------------------------------', file=sys.stderr)
-    logging.info('Combining output from {} runs with: '.format(len(starts)) + combine_command)
+    logging.info('Combining output from {} runs with: '.format(len(params)) + combine_command)
 
     p = subprocess.Popen(combine_command,
                          shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -182,9 +261,11 @@ def dsuite_combine(sets_fn, run_name, starts, lines_per_core, tree_fn=None,
         if e:
             logging.debug(e)
             logging.info('Successfully combined {} runs into output files'
-              ' with base {}.'.format(len(starts),
-                                                os.path.join(sets_dir,"out_" +
-                                                            run_name+'_combined')))
+              ' with base {}'.format(len(params),
+                                                os.path.join(sets_dir,out_prefix + '_' + sets_base + '_' +
+                                                            run_name+'_combined_*')))
+
+
 
     #print('------------------------------------------------------', file=sys.stderr)
 
@@ -196,7 +277,7 @@ def dsuite_combine(sets_fn, run_name, starts, lines_per_core, tree_fn=None,
             for ex in extensions:
                 intermediate_files.append(b+ex)
 
-        p = subprocess.Popen('rm {}'.format(' '.join(intermediate_files)),
+        p = subprocess.Popen('cd {}; rm {}'.format(sets_dir, ' '.join(intermediate_files)),
                              shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         o, e = p.communicate()
@@ -204,25 +285,40 @@ def dsuite_combine(sets_fn, run_name, starts, lines_per_core, tree_fn=None,
         e = e.decode('utf-8')
         if o:
             print(o, file=sys.stdout)
-        if e:
-            logging.error(o, file=sys.stderr)
-            
+        if p.returncode:
+            logging.error(e)
+
     return p.returncode 
 
 
 
 
 def main():
+
+
+    class SplitArgs(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            setattr(namespace, self.dest, [int(s) for s in values.split(',')])
+
+
     parser = argparse.ArgumentParser(description=("This python script automates parallelisation of Dsuite Dtrios/ Dsuite DtriosCombine. "
                                                   "The usage is analogous to Dsuite Dtrios but computation is performed "
                                                   " on multiple cores (default: number of available CPUs). "
-                                                  "It should run on most systems with a standard python installation "
+                                                  "[ATTENTION: The order of SETS.txt and INPUT_FILE.vcf is swapped compared "
+                                                  " to Dsuite Dtrios. This is so that multiple VCF intput files can be provided.]"
+                                                  " Output_files are  placed in the same folder as as the the SETS.txt file "
+                                                  " and named DTParallel_<SETS_basename>_<run_name>_combined_BBAA.txt etc. ."
+                                                  "This script should run on most systems with a standard python installation "
                                                   "(tested with python 2.7 and 3.6)."))
-    parser.add_argument("vcf_fn", metavar="INPUT_FILE.vcf")
     parser.add_argument("sets_fn", metavar="SETS.txt",
                         help=("The SETS.txt should have two columns: SAMPLE_ID    SPECIES_ID\n"
                         "The outgroup (can be multiple samples) should be specified by using the "
                         "keyword Outgroup in place of the SPECIES_ID"))
+
+
+
+    parser.add_argument("vcf_fns", metavar="INPUT_FILE.vcf", nargs='+', help="One or more whitespace separated SNP vcf files.")
+
 
 
     #DSUITE options
@@ -244,9 +340,12 @@ def main():
                         help="run-name will be included in the output file name",
                         required=False)
 
-    parser.add_argument("-l",metavar='NUMLINES', type=int,
-                                help=("(optional) the number of lines (SNPs) in the VCF input - speeds up operation if known"),
-                                                        default=None)
+    parser.add_argument("-l",metavar='NUMLINES',
+                                help=("(optional) the number of lines (SNPs) in the VCF input(s) - speeds up operation if known. "
+                                      " If N INPUT_FILE.vcf files are provided, there must be N comma-separated integers provided "
+                                      "without whitespace between them."
+                                      ),
+                                                        default=None,action=SplitArgs)
 
     parser.add_argument("-g", "--use-genotype-probabilities", action='store_true',
                         help=("(optional) use probabilities (GP tag) or calculate them from "
@@ -288,7 +387,16 @@ def main():
 
     if unknown:
         logger.warning("The following unrecognized arguments are not used: {}".format(unknown))
-   
+
+    if args.sets_fn.endswith('vcf.gz') or args.sets_fn.endswith('vcf'):
+        parser.print_usage()
+        print('\n')
+        raise Exception("SETS.txt file seems to have a vcf extension. "
+                        "Note that the SETS.txt file should be in the command line before the INPUT_FILE.vcf file(s)."
+                        "The order is swapped compared to Dsuite Dtrios to allow for multiple vcf files. "
+                        "\nThis is the sets filename: {}".format(args.sets_fn))
+
+
     def which(program):
         def is_exe(fpath):
             return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
@@ -329,18 +437,21 @@ def main():
     if args.JKwindow is not None:
         args.JKnum = None
 
-
-    vcf_fn = os.path.abspath(args.vcf_fn)
+    vcf_fns = [os.path.abspath(vcf_fn) for vcf_fn in args.vcf_fns]
     sets_fn = os.path.abspath(args.sets_fn)
-
-    if args.l is None:
-        n_snps = get_n_snps(args.vcf_fn)
-    else:
-        n_snps = args.l
+    if args.tree is not None:
+        args.tree = os.path.abspath(args.tree)
 
 
-    lines_per_core, starts = dsuite_dtrios(vcf_fn, sets_fn, args.run_name, args.cores, tree_fn=args.tree,
-                                            n_snps=n_snps, JKnum=args.JKnum, JKwindow=args.JKwindow,dsuite_path=args.dsuite_path,
+    if args.l is not None:
+        assert len(args.l) == len(vcf_fns), ("Comma separated line numbers provided do "
+                                            "not match number of INPUT_FILE.vcf files provided. Line numbers: {}; Vcf files: {}".format(args.l, args.vcf_fns))
+
+
+
+
+    params  = dsuite_dtrios(vcf_fns, sets_fn, args.run_name, args.cores, tree_fn=args.tree,
+                                            n_snps=args.l, JKnum=args.JKnum, JKwindow=args.JKwindow,dsuite_path=args.dsuite_path,
                                             environment_setup=args.environment_setup,
                                            use_genotype_probabilities=args.use_genotype_probabilities,
                                             pool_seq=args.pool_seq)
@@ -349,7 +460,7 @@ def main():
     #starts = range(1, n_snps, lines_per_core)
 
     if not args.no_combine:
-        rc = dsuite_combine(sets_fn, args.run_name, starts, lines_per_core, tree_fn=args.tree,
+        rc = dsuite_combine(params , args.run_name, sets_fn, tree_fn=args.tree,
                             remove_intermediate_files=not args.keep_intermediate, dsuite_path=args.dsuite_path,
                                                                         environment_setup=args.environment_setup)
 


### PR DESCRIPTION
Hello Milan,

As requested I have updated DtriosParallel with the options `--use-genotype-probabilities`  and `--pool-seq=MIN_DEPTH`.

Also I have rewritten the code to be able to handle multiple VCF files as input. I think this could be very useful for many people that have per-chromosome vcf files. They don't need to worry about the DTriosCombine anymore, it is done for them by the script. The implementation was not straightforward, because I had to optimise the splits of the different files depending on both `n_cores` and line numers of the vcf files and at the same time limit the processes to `n_cores`.

I tested it on python 2.7 and 3.9 and think it should work without installing any additional libraries. Would be good if you could test it a bit.

Hannes  

