### PR TITLE
Add missing <iterator> header for newer `gcc` compilers

### DIFF
--- a/Dsuite_utils.h
+++ b/Dsuite_utils.h
@@ -18,6 +18,7 @@
 #include <assert.h>
 #include <time.h>
 #include <regex>
+#include <iterator>
 #include <algorithm>
 #include <limits>
 #include <random>


### PR DESCRIPTION
`<iterator>` is no longer included in `<regex>` in newer `gcc` compilers, and should be included explicitly.

Should fix #92